### PR TITLE
Fixing Day 1 Bug

### DIFF
--- a/bot/replies/day1s/say_why_4.yml.erb
+++ b/bot/replies/day1s/say_why_4.yml.erb
@@ -1,4 +1,4 @@
-<% if current_message.message == "I sure wasn't" %>
+<% if current_message.message == "I sure wasn’t" %>
   - reply_type: text
     replies:
       - text: "I'm sorry to hear that. You're not alone!"


### PR DESCRIPTION
**What**

This PR fixes a bug where a specific response wasn't being detected because it was expecting a ` instead of a '

**Clubhouse Story**

https://app.clubhouse.io/renalis/story/13580/day-1-issue-the-correct-response-does-not-come-up