### PR TITLE
Support For Logical Flow Based on Categorization

### DIFF
--- a/bot/controllers/bot_controller.rb
+++ b/bot/controllers/bot_controller.rb
@@ -76,7 +76,6 @@ class BotController < Stealth::Controller
 
         matching_state = value if string_to_check == current_message.message
       elsif key[/^payload\[\:(.+)\]=(.+)$/, 1]
-        p payload_hash
         # Figure out what the payload field we're supposed to check against
         string_to_check = key.split("=").last
         payload_field = key[/^payload\[\:(.+)\]=(.+)$/, 1]

--- a/bot/controllers/bot_controller.rb
+++ b/bot/controllers/bot_controller.rb
@@ -50,21 +50,23 @@ class BotController < Stealth::Controller
       update_session_to state: flow_map[m][:next]
     elsif m.to_s.starts_with?("get_")
       router = flow_map[m][:next]
-      step_to state: get_next_state(router, current_message)
+      step_to state: get_next_state(router)
     else
       super
     end
   end
 
-  def get_next_state(router, current_message)
-    # If it's a string then we just route to it
-    return router if router.is_a? String
-
-    # Otherwise we will do some logic to determine which route the user should go to
-    detect_match(router, current_message)
+  def get_next_state(router)
+    if router.is_a? String
+      # If it's a string then we just route to it
+      router
+    else
+      # Otherwise we will do some logic to determine which route the user should go to
+      detect_match(router)
+    end
   end
 
-  def detect_match(router, current_message)
+  def detect_match(router)
     matching_state = ""
 
     router.each do |key, value|

--- a/bot/controllers/bot_controller.rb
+++ b/bot/controllers/bot_controller.rb
@@ -39,4 +39,53 @@ class BotController < Stealth::Controller
       end
     end
   end
+
+  def payload_hash
+    @payload_hash ||= JSON.parse(current_message.payload.gsub("=>", ":"))
+  end
+
+  def method_missing(m, *args, &block)
+    if m.to_s.starts_with?("say_")
+      send_replies
+      update_session_to state: flow_map[m][:next]
+    elsif m.to_s.starts_with?("get_")
+      router = flow_map[m][:next]
+      step_to state: get_next_state(router, current_message)
+    else
+      super
+    end
+  end
+
+  def get_next_state(router, current_message)
+    # If it's a string then we just route to it
+    return router if router.is_a? String
+
+    # Otherwise we will do some logic to determine which route the user should go to
+    detect_match(router, current_message)
+  end
+
+  def detect_match(router, current_message)
+    matching_state = ""
+
+    router.each do |key, value|
+      if key[/^message=(.+)$/, 1]
+        # Check the string against what the actual message sent was
+        string_to_check = key[/^message=(.+)$/, 1]
+
+        matching_state = value if string_to_check == current_message.message
+      elsif key[/^payload\[\:(.+)\]=(.+)$/, 1]
+        p payload_hash
+        # Figure out what the payload field we're supposed to check against
+        string_to_check = key.split("=").last
+        payload_field = key[/^payload\[\:(.+)\]=(.+)$/, 1]
+
+        matching_state = value if payload_hash[payload_field] == string_to_check
+      elsif key == current_message.message
+        matching_state = value
+      end
+    end
+
+    matching_state
+  end
+
 end

--- a/bot/controllers/day10s_controller.rb
+++ b/bot/controllers/day10s_controller.rb
@@ -1,18 +1,7 @@
 class Day10sController < BotController
 
-  def method_missing(m, *args, &block)
-    p "HITTING THIS?"
-    if m.to_s.starts_with?("say_")
-      send_replies
-      update_session_to state: Day10Flow::DAY_10_FLOWS[m][:next]
-    elsif m.to_s.starts_with?("get_")
-      next_state = Day10Flow::DAY_10_FLOWS[m][:next]
-      if next_state.is_a? String
-        step_to state: next_state
-      else
-        step_to state: next_state[current_message.message]
-      end
-    end
+  def flow_map
+    Day10Flow::DAY_10_FLOWS
   end
 
   def say_goodbye

--- a/bot/controllers/day11s_controller.rb
+++ b/bot/controllers/day11s_controller.rb
@@ -1,17 +1,7 @@
 class Day11sController < BotController
 
-  def method_missing(m, *args, &block)
-    if m.to_s.starts_with?("say_")
-      send_replies
-      update_session_to state: Day11Flow::DAY_11_FLOWS[m][:next]
-    elsif m.to_s.starts_with?("get_")
-      next_state = Day11Flow::DAY_11_FLOWS[m][:next]
-      if next_state.is_a? String
-        step_to state: next_state
-      else
-        step_to state: next_state[current_message.message]
-      end
-    end
+  def flow_map
+    Day11Flow::DAY_11_FLOWS
   end
 
   def say_goodbye

--- a/bot/controllers/day12s_controller.rb
+++ b/bot/controllers/day12s_controller.rb
@@ -1,17 +1,7 @@
 class Day12sController < BotController
 
-  def method_missing(m, *args, &block)
-    if m.to_s.starts_with?("say_")
-      send_replies
-      update_session_to state: Day12Flow::DAY_12_FLOWS[m][:next]
-    elsif m.to_s.starts_with?("get_")
-      next_state = Day12Flow::DAY_12_FLOWS[m][:next]
-      if next_state.is_a? String
-        step_to state: next_state
-      else
-        step_to state: next_state[current_message.message]
-      end
-    end
+  def flow_map
+    Day12Flow::DAY_12_FLOWS
   end
 
   def say_goodbye

--- a/bot/controllers/day13s_controller.rb
+++ b/bot/controllers/day13s_controller.rb
@@ -1,17 +1,7 @@
 class Day13sController < BotController
 
-  def method_missing(m, *args, &block)
-    if m.to_s.starts_with?("say_")
-      send_replies
-      update_session_to state: Day13Flow::DAY_13_FLOWS[m][:next]
-    elsif m.to_s.starts_with?("get_")
-      next_state = Day13Flow::DAY_13_FLOWS[m][:next]
-      if next_state.is_a? String
-        step_to state: next_state
-      else
-        step_to state: next_state[current_message.message]
-      end
-    end
+  def flow_map
+    Day13Flow::DAY_13_FLOWS
   end
 
   def say_goodbye

--- a/bot/controllers/day14s_controller.rb
+++ b/bot/controllers/day14s_controller.rb
@@ -1,17 +1,7 @@
 class Day14sController < BotController
 
-  def method_missing(m, *args, &block)
-    if m.to_s.starts_with?("say_")
-      send_replies
-      update_session_to state: Day14Flow::DAY_14_FLOWS[m][:next]
-    elsif m.to_s.starts_with?("get_")
-      next_state = Day14Flow::DAY_14_FLOWS[m][:next]
-      if next_state.is_a? String
-        step_to state: next_state
-      else
-        step_to state: next_state[current_message.message]
-      end
-    end
+  def flow_map
+    Day14Flow::DAY_14_FLOWS
   end
 
   def say_goodbye

--- a/bot/controllers/day4s_controller.rb
+++ b/bot/controllers/day4s_controller.rb
@@ -1,17 +1,7 @@
 class Day4sController < BotController
 
-  def method_missing(m, *args, &block)
-    if m.to_s.starts_with?("say_")
-      send_replies
-      update_session_to state: Day4Flow::DAY_4_FLOWS[m][:next]
-    elsif m.to_s.starts_with?("get_")
-      next_state = Day4Flow::DAY_4_FLOWS[m][:next]
-      if next_state.is_a? String
-        step_to state: next_state
-      else
-        step_to state: next_state[current_message.message]
-      end
-    end
+  def flow_map
+    Day4Flow::DAY_4_FLOWS
   end
 
   def say_goodbye

--- a/bot/controllers/day5s_controller.rb
+++ b/bot/controllers/day5s_controller.rb
@@ -1,17 +1,7 @@
 class Day5sController < BotController
 
-  def method_missing(m, *args, &block)
-    if m.to_s.starts_with?("say_")
-      send_replies
-      update_session_to state: Day5Flow::DAY_5_FLOWS[m][:next]
-    elsif m.to_s.starts_with?("get_")
-      next_state = Day5Flow::DAY_5_FLOWS[m][:next]
-      if next_state.is_a? String
-        step_to state: next_state
-      else
-        step_to state: next_state[current_message.message]
-      end
-    end
+  def flow_map
+    Day5Flow::DAY_5_FLOWS
   end
 
   def say_goodbye

--- a/bot/controllers/day6s_controller.rb
+++ b/bot/controllers/day6s_controller.rb
@@ -1,17 +1,7 @@
 class Day6sController < BotController
 
-  def method_missing(m, *args, &block)
-    if m.to_s.starts_with?("say_")
-      send_replies
-      update_session_to state: Day6Flow::DAY_6_FLOWS[m][:next]
-    elsif m.to_s.starts_with?("get_")
-      next_state = Day6Flow::DAY_6_FLOWS[m][:next]
-      if next_state.is_a? String
-        step_to state: next_state
-      else
-        step_to state: next_state[current_message.message]
-      end
-    end
+  def flow_map
+    Day6Flow::DAY_6_FLOWS
   end
 
   def say_goodbye

--- a/bot/controllers/day7s_controller.rb
+++ b/bot/controllers/day7s_controller.rb
@@ -1,17 +1,7 @@
 class Day7sController < BotController
 
-  def method_missing(m, *args, &block)
-    if m.to_s.starts_with?("say_")
-      send_replies
-      update_session_to state: Day7Flow::DAY_7_FLOWS[m][:next]
-    elsif m.to_s.starts_with?("get_")
-      next_state = Day7Flow::DAY_7_FLOWS[m][:next]
-      if next_state.is_a? String
-        step_to state: next_state
-      else
-        step_to state: next_state[current_message.message]
-      end
-    end
+  def flow_map
+    Day7Flow::DAY_7_FLOWS
   end
 
   def say_goodbye

--- a/bot/controllers/day8s_controller.rb
+++ b/bot/controllers/day8s_controller.rb
@@ -1,17 +1,7 @@
 class Day8sController < BotController
 
-  def method_missing(m, *args, &block)
-    if m.to_s.starts_with?("say_")
-      send_replies
-      update_session_to state: Day8Flow::DAY_8_FLOWS[m][:next]
-    elsif m.to_s.starts_with?("get_")
-      next_state = Day8Flow::DAY_8_FLOWS[m][:next]
-      if next_state.is_a? String
-        step_to state: next_state
-      else
-        step_to state: next_state[current_message.message]
-      end
-    end
+  def flow_map
+    Day8Flow::DAY_8_FLOWS
   end
 
   def say_goodbye

--- a/bot/controllers/day9s_controller.rb
+++ b/bot/controllers/day9s_controller.rb
@@ -1,17 +1,7 @@
 class Day9sController < BotController
 
-  def method_missing(m, *args, &block)
-    if m.to_s.starts_with?("say_")
-      send_replies
-      update_session_to state: Day9Flow::DAY_9_FLOWS[m][:next]
-    elsif m.to_s.starts_with?("get_")
-      next_state = Day9Flow::DAY_9_FLOWS[m][:next]
-      if next_state.is_a? String
-        step_to state: next_state
-      else
-        step_to state: next_state[current_message.message]
-      end
-    end
+  def flow_map
+    Day9Flow::DAY_9_FLOWS
   end
 
   def say_goodbye


### PR DESCRIPTION
**What**
This PR makes it so that a user can be routed to certain flows depending on categorization fields on their profile

Right now a flow that contains multiple possible routes based on the user's message looks like this:
```
get_feedback_1_response: {
  next: {
    "Sure" => "say_feedback_2",
    "No thanks" => "say_intro_2_no_feedback"
  }
},
```
It will be updated to support routing based on the payload data as well as the user's message
It now can look like this:
```
get_feedback_1_response: {
  next: {
    "payload[:category]=category_1" => "say_feedback_for_category"
    "message=Sure" => "say_feedback_2",
    "message=No thanks" => "say_intro_2_no_feedback"
  }
},
```

**Link to story**
https://app.clubhouse.io/renalis/story/13231/user-flow-based-on-past-answers

**List of changes**
- Moved all of the individual day controllers methodmissing function to the parent BotController
- New logic in methodmissing function to detect if it should be routing based on a payload field, or message text
- It is backwards compatible with the existing STTR chat flows